### PR TITLE
feat: add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,10 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           TAG_NAME: ${{ inputs.tag_name }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git add package.json package-lock.json
           git commit -m "chore: bump version to ${VERSION}" || echo "No changes to commit"
           git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: Release Builds
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag (e.g., v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write  # Required for creating releases and pushing commits
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create_release.outputs.id }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0  # Fetch all history for release notes generation
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2.3.2
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          name: Release ${{ inputs.tag_name }}
+          draft: true
+          prerelease: false
+          generate_release_notes: true
+
+  update-version:
+    needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Get version from tag
+        id: get_version
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          VERSION="${TAG_NAME}"
+          VERSION="${VERSION#v}"  # Remove 'v' prefix if present
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update package.json version
+        run: |
+          npm version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version --allow-same-version
+
+      - name: Commit version update
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to ${VERSION}" || echo "No changes to commit"
+          git push origin HEAD:main
+          git tag -f "${TAG_NAME}"
+          git push origin "${TAG_NAME}" --force
+
+  build:
+    needs: [create-release, update-version]
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win
+            artifact: opencook-*.exe
+            artifact-name: opencook-portable-win
+          - os: ubuntu-latest
+            platform: linux
+            artifact: opencook-*.AppImage
+            artifact-name: opencook-appimage-linux
+          - os: macos-latest
+            platform: mac
+            artifact: opencook-*.dmg
+            artifact-name: opencook-dmg-mac
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+        with:
+          ref: main  # Get the latest code including version update
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build for ${{ matrix.platform }}
+        run: npm run build:${{ matrix.platform }}
+
+      - name: Upload artifacts to release
+        uses: softprops/action-gh-release@v2.3.2
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          files: |
+            dist/${{ matrix.artifact }}
+          draft: true  # Keep as draft during upload
+
+  publish-release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish release
+        uses: softprops/action-gh-release@v2.3.2
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          draft: false  # Publish the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 permissions:
-  contents: write  # Required for creating releases and pushing commits
+  contents: write # Required for creating releases and pushing commits
 
 jobs:
   create-release:
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
         with:
-          fetch-depth: 0  # Fetch all history for release notes generation
+          fetch-depth: 0 # Fetch all history for release notes generation
 
       - name: Create Release
         id: create_release
@@ -94,8 +94,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
         with:
-          ref: main  # Get the latest code including version update
-
+          ref: main # Get the latest code including version update
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -114,7 +113,7 @@ jobs:
           tag_name: ${{ inputs.tag_name }}
           files: |
             dist/${{ matrix.artifact }}
-          draft: true  # Keep as draft during upload
+          draft: true # Keep as draft during upload
 
   publish-release:
     needs: build
@@ -124,4 +123,4 @@ jobs:
         uses: softprops/action-gh-release@v2.3.2
         with:
           tag_name: ${{ inputs.tag_name }}
-          draft: false  # Publish the release
+          draft: false # Publish the release


### PR DESCRIPTION
## Summary
- Added automated release workflow triggered via workflow_dispatch
- Creates draft releases with auto-generated release notes
- Builds and uploads binaries for Windows (portable exe), Linux (AppImage), and macOS (dmg)

## Features
- Manual trigger with tag input (e.g., v1.0.0)
- Automatic version update in package.json with commit
- Parallel builds across all platforms
- Security best practices (scoped permissions, input sanitization)
- Uses triggering user for version commits
- Automatically publishes release after all artifacts are uploaded

## Usage
1. Go to Actions tab → Release Builds → Run workflow
2. Enter release tag (e.g., v1.0.0)
3. Workflow creates release, builds, and publishes automatically